### PR TITLE
Fix admin login redirect paths

### DIFF
--- a/admin/auth/guard.php
+++ b/admin/auth/guard.php
@@ -6,7 +6,7 @@ require_once __DIR__ . '/../lib/helpers.php';
 start_session();
 
 if (empty($_SESSION['admin'])) {
-  redirect(BASE_URL . '/login.php');
+  redirect('/login.php');
 
 }
 

--- a/admin/auth/handle-login.php
+++ b/admin/auth/handle-login.php
@@ -6,7 +6,7 @@ require_once __DIR__ . '/../lib/db.php';
 require_once __DIR__ . '/../lib/helpers.php';
 require_once __DIR__ . '/csrf.php';
 
-if (!method_is('POST')) { redirect(BASE_URL . '/login.php');
+if (!method_is('POST')) { redirect('/login.php');
  }
 csrf_verify();
 
@@ -15,7 +15,7 @@ $pass  = (string)($_POST['password'] ?? '');
 
 if ($email === '' || $pass === '') {
   flash('error', 'Email and password required.');
-  redirect(BASE_URL . '/login.php');
+  redirect('/login.php');
 
 }
 
@@ -25,7 +25,7 @@ $user = $stmt->fetch();
 
 if (!$user || !(bool)$user['is_active'] || !password_verify($pass, $user['password_hash'])) {
   flash('error', 'Invalid credentials.');
-  redirect(BASE_URL . '/login.php');
+  redirect('/login.php');
 
 }
 
@@ -38,4 +38,4 @@ $_SESSION['admin'] = [
   'login_at' => date('c'),
 ];
 
-redirect(BASE_URL . '/index.php');
+redirect('/index.php');

--- a/admin/logout.php
+++ b/admin/logout.php
@@ -4,5 +4,5 @@ require_once __DIR__ . '/lib/helpers.php';
 start_session();
 $_SESSION = [];
 session_destroy();
-redirect(BASE_URL . '/login.php');
+redirect('/login.php');
 


### PR DESCRIPTION
## Summary
- Correct admin redirect calls to avoid double `/admin` prefixes.
- Ensure login handler, guard, and logout route redirect relative to base URL.

## Testing
- `php -l admin/auth/guard.php`
- `php -l admin/auth/handle-login.php`
- `php -l admin/logout.php`
- `curl -s -b cookie.txt -d "email=test@example.com" -d "password=secret" -d "_csrf=6f980cd37019913518cde0cc366a21a488a949358817c4cc81097dc32f7c4c7a" -D - http://127.0.0.1:8000/auth/handle-login.php | head -n 20` *(fails: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6899b1f4c9e88332a1fe68be198ebd08